### PR TITLE
add "masters" in mesos-dns/config.js

### DIFF
--- a/mesos-dns/config.js
+++ b/mesos-dns/config.js
@@ -1,5 +1,6 @@
 {
   "zk": "zk://127.0.0.1:2181/mesos",
+  "masters": ["127.0.0.1:5050"],  
   "refreshSeconds": 60,
   "ttl": 60,
   "domain": "mesos",


### PR DESCRIPTION
Per documentation on https://mesosphere.github.io/mesos-dns/docs/configuration-parameters.html, "masters" a required field in it's configuration. I verified that mesos-dns lookups don't work otherwise in m-shop.
